### PR TITLE
Link zlib statically via libz-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,7 @@ required-features = ["binary"]
 [dependencies]
 arguments = { version = "0.8", optional = true }
 libc = { version = "0.2", default-features = false }
-
-[dependencies.libz-sys]
-version = "1.1"
-features = ["static"]
+libz-sys = { version = "1.1", features = ["static"] }
 
 [build-dependencies]
 cc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ required-features = ["binary"]
 arguments = { version = "0.8", optional = true }
 libc = { version = "0.2", default-features = false }
 
+[dependencies.libz-sys]
+version = "1.1"
+features = ["static"]
+
 [build-dependencies]
 cc = "1"
 

--- a/build.rs
+++ b/build.rs
@@ -3,15 +3,16 @@ fn main() {
     let target = std::env::var("TARGET").unwrap();
 
     #[cfg(feature = "version1")]
-    cc::Build::new()
-        .include("vendor/sfnt2woff/source/woff")
-        .file("vendor/sfnt2woff/source/woff/woff.c")
-        .static_flag(true)
-        .warnings(false)
-        .compile("libsfnt2woff.a");
-
-    #[cfg(feature = "version1")]
-    println!("cargo:rustc-link-lib=z");
+    {
+        let zlib_include = std::env::var("DEP_Z_INCLUDE")                                                                                                                                                                                       
+          .expect("DEP_Z_INCLUDE should be set by libz-sys"); 
+        cc::Build::new()
+            .include("vendor/sfnt2woff/source/woff")
+            .include(&zlib_include)
+            .file("vendor/sfnt2woff/source/woff/woff.c")
+            .warnings(false)
+            .compile("libsfnt2woff.a");
+    }
 
     #[cfg(feature = "version2")]
     cc::Build::new()
@@ -20,7 +21,6 @@ fn main() {
         .file("vendor/woff2/wrapper/woff2.cpp")
         .include("vendor/woff2/source/include")
         .include("vendor/woff2/wrapper")
-        .static_flag(true)
         .warnings(false)
         .compile("libwoff2wrapper.a");
 
@@ -40,7 +40,6 @@ fn main() {
         .file("vendor/woff2/source/src/woff2_dec.cc")
         .file("vendor/woff2/source/src/woff2_enc.cc")
         .file("vendor/woff2/source/src/woff2_out.cc")
-        .static_flag(true)
         .warnings(false)
         .compile("libwoff2.a");
 
@@ -78,7 +77,6 @@ fn main() {
         .file("vendor/brotli/source/c/enc/metablock.c")
         .file("vendor/brotli/source/c/enc/static_dict.c")
         .file("vendor/brotli/source/c/enc/utf8_util.c")
-        .static_flag(true)
         .warnings(false)
         .compile("libbrotli.a");
 

--- a/build.rs
+++ b/build.rs
@@ -4,8 +4,8 @@ fn main() {
 
     #[cfg(feature = "version1")]
     {
-        let zlib_include = std::env::var("DEP_Z_INCLUDE")                                                                                                                                                                                       
-          .expect("DEP_Z_INCLUDE should be set by libz-sys"); 
+        let zlib_include =
+            std::env::var("DEP_Z_INCLUDE").expect("DEP_Z_INCLUDE should be set by libz-sys");
         cc::Build::new()
             .include("vendor/sfnt2woff/source/woff")
             .include(&zlib_include)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! Converter for Web Open Font Format.
 
+// Ensure libz-sys is linked (provides zlib for the vendored C code).
+#[cfg(feature = "version1")]
+use libz_sys as _;
 #[cfg(feature = "version1")]
 pub mod version1;
 #[cfg(feature = "version2")]


### PR DESCRIPTION
## Summary
- Removed redundant `.static_flag(true)` calls from all `cc::Build` blocks in `build.rs` — the `cc` crate already produces static `.a` archives, so the flag was a no-op
- Added `libz-sys` with `features = ["static"]` to `Cargo.toml` to ensure zlib is statically linked
- Added `use libz_sys as _` in `src/lib.rs` to guarantee the linker includes the static zlib for `version1`